### PR TITLE
Use symbol to unwrap value

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var util = require('util');
 
-module.exports = function safe(obj) {
+var value = Symbol('value');
+
+var safe = function safe(obj) {
   var target = isObject(obj) ? obj : function() {};
 
   return new Proxy(target, {
@@ -13,7 +15,7 @@ module.exports = function safe(obj) {
         }
       }
 
-      if (name === '__value') {
+      if (name === value) {
         return obj;
       }
 
@@ -35,6 +37,10 @@ module.exports = function safe(obj) {
     }
   });
 };
+
+safe.value = value;
+
+module.exports = safe;
 
 var isFunction = function(obj) {
   return typeof obj === 'function';

--- a/readme.md
+++ b/readme.md
@@ -16,20 +16,20 @@ Use `safe-proxy` like this:
 
 ```javascript
 var safe = require('safe-proxy');
-safe(obj).that.is.very.nested.__value;
+safe(obj).that.is.very.nested[safe.value];
 // the same as `obj.that.is.very.nested` EXCEPT
 // returns undefined if any property in the chain is undefined
 ```
 
-You can access arrays and call functions as you normally would. Just remember to access `__value` at the end.
+You can access arrays and call functions as you normally would. Just remember to access `[safe.value]` at the end.
 
 ```javascript
-safe(obj).nested.property.and.array[0].func('some', 'args').__value;
+safe(obj).nested.property.and.array[0].func('some', 'args')[safe.value];
 ```
 
 ## What's going on?
 
-You can think of calling `safe(obj)` as wrapping `obj` in an object which will not throw an error no matter what properties you access or functions you call on it (even if `obj` is undefined, for instance). In order to *unwrap* the value, you’ll need to access the special property `__value`.
+You can think of calling `safe(obj)` as wrapping `obj` in an object which will not throw an error no matter what properties you access or functions you call on it (even if `obj` is undefined, for instance). In order to *unwrap* the value, you’ll need to access the special property `value`, which is a symbol exported by `safe-proxy`.
 
 ## Development
 

--- a/test/test.js
+++ b/test/test.js
@@ -48,51 +48,51 @@ var safeBob = safe(bob);
 
 describe('safe-proxy', function() {
   it('should return a valid field', function() {
-    expect(safeObj.e.__value).to.equal('woo!');
+    expect(safeObj.e[safe.value]).to.equal('woo!');
   });
 
   it('should return undefined if an invalid field is accessed', function() {
-    expect(safeObj.randomField.__value).to.be.undefined();
+    expect(safeObj.randomField[safe.value]).to.be.undefined();
   });
 
   it('should return a valid nested field', function() {
-    expect(safeObj.a.b.f.__value).to.equal('boom!');
+    expect(safeObj.a.b.f[safe.value]).to.equal('boom!');
   });
 
   it('should return undefined if middle of chain is undefined', function() {
-    expect(safeObj.a.randomField.randomField.randomField.__value).to.be.undefined();
+    expect(safeObj.a.randomField.randomField.randomField[safe.value]).to.be.undefined();
   });
 
   it('should return null if property is null', function() {
-    expect(safeObj.a.b.g.__value).to.be.null;
+    expect(safeObj.a.b.g[safe.value]).to.be.null;
   });
 
   it('should return undefined if middle of chain returns null', function() {
-    expect(safeObj.a.b.g.randomField.__value).to.be.undefined();
+    expect(safeObj.a.b.g.randomField[safe.value]).to.be.undefined();
   });
 
   it('should return a valid non-primitive field', function() {
-    expect(safeObj.a.__value).to.equal(obj.a);
+    expect(safeObj.a[safe.value]).to.equal(obj.a);
   });
 
   it('should call a function', function() {
-    expect(safeObj.a.b.c().__value).to.equal('woo!');
+    expect(safeObj.a.b.c()[safe.value]).to.equal('woo!');
   });
 
   it('should return undefined if the function doesn\'t exist', function() {
-    expect(safeObj.a.b.randomField().__value).to.be.undefined();
+    expect(safeObj.a.b.randomField()[safe.value]).to.be.undefined();
   });
 
   it('should call a function with arguments', function() {
-    expect(safeObj.a.b.d(5).__value).to.equal(25);
+    expect(safeObj.a.b.d(5)[safe.value]).to.equal(25);
   });
 
   it('should be able to access properties on an object\'s prototype', function() {
-    expect(safeObj.a.b.h.length.__value).to.equal(3);
+    expect(safeObj.a.b.h.length[safe.value]).to.equal(3);
   });
 
   it('should retain this values', function() {
-    expect(safeObj.a.b.i().length.__value).to.equal(3);
+    expect(safeObj.a.b.i().length[safe.value]).to.equal(3);
   });
 
   it('should not throw an error if attempting to call a non-function as a function', function() {
@@ -100,22 +100,22 @@ describe('safe-proxy', function() {
   });
 
   it('should return undefined if we call a non-function', function() {
-    expect(safeObj.e().__value).to.be.undefined();
+    expect(safeObj.e()[safe.value]).to.be.undefined();
   });
 
   it('should return undefined if we try to call random properties', function() {
-    expect(safeObj.e().b().__value).to.be.undefined();
+    expect(safeObj.e().b()[safe.value]).to.be.undefined();
   });
 
   it('should call a safe object as a function', function() {
-    expect(safeFn().__value).to.equal('pow!');
+    expect(safeFn()[safe.value]).to.equal('pow!');
   });
 
   it('should be able to chain a safe function', function() {
-    expect(safeFn().prop.__value).to.be.undefined();
+    expect(safeFn().prop[safe.value]).to.be.undefined();
   });
 
   it('should be able to call properties on an instance of a class', function() {
-    expect(safeBob.getName().__value).to.equal('Bob');
+    expect(safeBob.getName()[safe.value]).to.equal('Bob');
   });
 });


### PR DESCRIPTION
Exports a symbol that you can use to "unwrap" the value instead of accessing `__value`.

See https://github.com/erictrinh/safe-proxy/issues/1 for discussion on this.

### Usage
```javascript
safe(config).nested.obj.__value // before
safe(config).nested.obj[safe.value] // after
```

### Todo
- [x] Update readme